### PR TITLE
fix(PublicKeyLoader): reloadKeys does not throw on unreachable source

### DIFF
--- a/src/key/PublicKeyLoader.ts
+++ b/src/key/PublicKeyLoader.ts
@@ -24,7 +24,10 @@ export default class PublicKeyLoader {
       keys.push(keySource.loadKeysFromSource());
     }
 
-    const keyResults = (await Promise.all(keys)).flat();
+    const keyResults = (await Promise.allSettled(keys))
+      .filter((p) => p.status === "fulfilled")
+      .map((p) => p as PromiseFulfilledResult<LoadedPublicKey[]>)
+      .flatMap((p) => p.value);
 
     // Reset all keys to remove expired keys
     this.keysByKid.clear();

--- a/src/key/PublicKeyLoader.unit.test.ts
+++ b/src/key/PublicKeyLoader.unit.test.ts
@@ -35,6 +35,16 @@ describe("publicKeyLoader", () => {
     });
   });
 
+  describe("reloadKeys", () => {
+    it("should not throw if a keysource is not available", async () => {
+      await publicKeyLoader.addKeySource({
+        loadKeysFromSource: () => Promise.reject(new Error("test")),
+      } as KeySource);
+
+      await expect(publicKeyLoader.reloadKeys()).resolves.toBeUndefined();
+    });
+  });
+
   describe("getLoadedPublicKey", () => {
     it("should return null if no key is found", async () => {
       await expect(


### PR DESCRIPTION
This fixes an issue where an unreachable source would produce an application crash