### PR TITLE
fix(OPAGuard): context path starts with /

### DIFF
--- a/src/OPAGuard.ts
+++ b/src/OPAGuard.ts
@@ -40,7 +40,6 @@ export default class OPAGuard implements CanActivate {
     const prefix = contextPath.endsWith("/") ? contextPath : contextPath + "/";
     const method = request.method;
 
-
     const requestUrl = request.url.substring(prefix.length - 1);
 
     if (!authorization) {

--- a/src/OpaGuard.unit.test.ts
+++ b/src/OpaGuard.unit.test.ts
@@ -126,9 +126,9 @@ describe("opaGuard", () => {
           expected,
           {
             authorization: "Bearer " + token,
-          }
+          },
         );
-      }
+      },
     );
   });
 });


### PR DESCRIPTION
This fixes an error where the http context path would not be generated accordingly
 and therefore  OPA Evaluation woul result in an error