### PR TITLE
fix(OpaGuard): query params are not relayed tin the Path

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,9 @@ allow {
     # allow if path match '/contracts/:anyid'
     input.path = ["contracts", _]
 
+    # Require the querystring to contain a=b as of 'GET /contracts?a=b'
+    "b" in input.query["a"]
+
     # allow if request method 'GET' is used
     input.httpMethod == "GET"
 

--- a/src/OpaGuard.unit.test.ts
+++ b/src/OpaGuard.unit.test.ts
@@ -181,7 +181,7 @@ describe("opaGuard", () => {
               authorization: "Bearer " + token,
             }),
           );
-        }
+        },
       );
     });
   });

--- a/src/OpaGuard.unit.test.ts
+++ b/src/OpaGuard.unit.test.ts
@@ -181,7 +181,7 @@ describe("opaGuard", () => {
               authorization: "Bearer " + token,
             }),
           );
-        },
+        }
       );
     });
   });

--- a/src/service/OPAService.ts
+++ b/src/service/OPAService.ts
@@ -44,7 +44,7 @@ export default class OPAService {
   constructor(
     private readonly httpService: HttpService,
     @Inject(AUTH_MODULE_OPTIONS_TOKEN)
-    private readonly authOpts: AuthModuleOptions
+    private readonly authOpts: AuthModuleOptions,
   ) {}
 
   /**
@@ -56,7 +56,7 @@ export default class OPAService {
     token: string,
     httpMethod: string,
     path: string,
-    headers: Record<string, string>
+    headers: Record<string, string>,
   ): Promise<OpaJwtPrincipal["constraints"]> {
     const config = this.authOpts.opa;
     const disable = config.disableOpa === true;
@@ -107,7 +107,7 @@ export default class OPAService {
           "Content-Type": "application/json",
         },
         timeout: config.opaClient?.timeout ?? 500,
-      }
+      },
     );
 
     const claims = await this.transformResponse(res);
@@ -127,7 +127,7 @@ export default class OPAService {
   }
 
   private transformResponse(
-    res: Observable<AxiosResponse<OPAResponse>>
+    res: Observable<AxiosResponse<OPAResponse>>,
   ): Promise<OpaJwtPrincipal["constraints"]> {
     const obs: Observable<OpaJwtPrincipal["constraints"]> = new Observable(
       (subscriber) => {
@@ -157,7 +157,7 @@ export default class OPAService {
             subscriber.complete();
           },
         });
-      }
+      },
     );
 
     return lastValueFrom(obs);

--- a/src/service/OPAService.ts
+++ b/src/service/OPAService.ts
@@ -75,7 +75,7 @@ export default class OPAService {
     this.logger.verbose("OPA URL: " + callUrl);
 
     // We only rely on this for the path, so we can use any host
-    const url = new URL(path, "http://invalid.host");
+    const url = new URL(path, "https://invalid.host");
 
     const pathname = url.pathname;
 

--- a/src/service/OPAService.ts
+++ b/src/service/OPAService.ts
@@ -44,7 +44,7 @@ export default class OPAService {
   constructor(
     private readonly httpService: HttpService,
     @Inject(AUTH_MODULE_OPTIONS_TOKEN)
-    private readonly authOpts: AuthModuleOptions,
+    private readonly authOpts: AuthModuleOptions
   ) {}
 
   /**
@@ -56,7 +56,7 @@ export default class OPAService {
     token: string,
     httpMethod: string,
     path: string,
-    headers: Record<string, string>,
+    headers: Record<string, string>
   ): Promise<OpaJwtPrincipal["constraints"]> {
     const config = this.authOpts.opa;
     const disable = config.disableOpa === true;
@@ -74,11 +74,25 @@ export default class OPAService {
 
     this.logger.verbose("OPA URL: " + callUrl);
 
+    // We only rely on this for the path, so we can use any host
+    const url = new URL(path, "http://invalid.host");
+
+    const pathname = url.pathname;
+
+    const queries: Record<string, string[]> = {};
+
+    url.searchParams.forEach((v, k) => {
+      const values = queries[k] ?? [];
+      values.push(v);
+      queries[k] = values;
+    });
+
     const input = {
       token,
       httpMethod,
-      path: path.substring(1).split("/"),
+      path: pathname.substring(1).split("/"),
       headers,
+      query: queries,
     };
 
     this.logger.verbose("OPA input: " + inspect(input));
@@ -93,7 +107,7 @@ export default class OPAService {
           "Content-Type": "application/json",
         },
         timeout: config.opaClient?.timeout ?? 500,
-      },
+      }
     );
 
     const claims = await this.transformResponse(res);
@@ -113,7 +127,7 @@ export default class OPAService {
   }
 
   private transformResponse(
-    res: Observable<AxiosResponse<OPAResponse>>,
+    res: Observable<AxiosResponse<OPAResponse>>
   ): Promise<OpaJwtPrincipal["constraints"]> {
     const obs: Observable<OpaJwtPrincipal["constraints"]> = new Observable(
       (subscriber) => {
@@ -143,7 +157,7 @@ export default class OPAService {
             subscriber.complete();
           },
         });
-      },
+      }
     );
 
     return lastValueFrom(obs);

--- a/src/service/OPAService.unit.test.ts
+++ b/src/service/OPAService.unit.test.ts
@@ -93,7 +93,7 @@ describe("opaService", () => {
           token,
           headers: request.headers,
           httpMethod: "TEST",
-          path: ["test", "test"],
+          path: ["test", "test"],query:{}
         },
       },
       {
@@ -129,7 +129,7 @@ describe("opaService", () => {
           token,
           httpMethod: "TEST",
           path: ["test", "test"],
-          headers: request.headers,
+          headers: request.headers,query:{}
         },
       },
       {
@@ -171,7 +171,49 @@ describe("opaService", () => {
           token,
           httpMethod: "TEST",
           path: ["test", "test"],
-          headers: request.headers,
+          headers: request.headers,query:{}
+        },
+      },
+      { headers: { "Content-Type": "application/json" }, timeout: 500 },
+    );
+  });
+
+  it("should relay query parameters to OPA", async () => {
+    httpService.post.mockReturnValueOnce(
+      new Observable((s) => {
+        s.next({
+          data: {
+            result: {
+              test: { allow: true },
+            },
+          },
+        });
+        s.complete();
+      }) as never,
+    );
+
+    request.url = "/test/test?param1=value1&param2=value2&param2=value3";
+
+    const result = opaService.auth(
+      request,
+      token,
+      request.method,
+      request.url,
+      request.headers,
+    );
+
+    await expect(result).rejects.toThrow("ERR_OPA_FORBIDDEN");
+    expect(httpService.post).toHaveBeenCalledWith(
+      "https://example.com/v1/data/test",
+      {
+        input: {
+          token,
+          httpMethod: "TEST",
+          path: ["test", "test"],
+          headers: request.headers,query:{
+            param1: ["value1"],
+            param2: ["value2", "value3"],
+          }
         },
       },
       { headers: { "Content-Type": "application/json" }, timeout: 500 },

--- a/src/service/OPAService.unit.test.ts
+++ b/src/service/OPAService.unit.test.ts
@@ -93,7 +93,8 @@ describe("opaService", () => {
           token,
           headers: request.headers,
           httpMethod: "TEST",
-          path: ["test", "test"],query:{}
+          path: ["test", "test"],
+          query: {},
         },
       },
       {
@@ -129,7 +130,8 @@ describe("opaService", () => {
           token,
           httpMethod: "TEST",
           path: ["test", "test"],
-          headers: request.headers,query:{}
+          headers: request.headers,
+          query: {},
         },
       },
       {
@@ -171,7 +173,8 @@ describe("opaService", () => {
           token,
           httpMethod: "TEST",
           path: ["test", "test"],
-          headers: request.headers,query:{}
+          headers: request.headers,
+          query: {},
         },
       },
       { headers: { "Content-Type": "application/json" }, timeout: 500 },
@@ -210,10 +213,11 @@ describe("opaService", () => {
           token,
           httpMethod: "TEST",
           path: ["test", "test"],
-          headers: request.headers,query:{
+          headers: request.headers,
+          query: {
             param1: ["value1"],
             param2: ["value2", "value3"],
-          }
+          },
         },
       },
       { headers: { "Content-Type": "application/json" }, timeout: 500 },


### PR DESCRIPTION
This fixes an error, where query parameters would incorrectly be placed inside the path of an URL